### PR TITLE
link hacking, update jupyter_contrib_core dep

### DIFF
--- a/recipes/jupyter_contrib_nbextensions/meta.yaml
+++ b/recipes/jupyter_contrib_nbextensions/meta.yaml
@@ -18,22 +18,12 @@ build:
 requirements:
   build:
     - python
-    - ipython_genutils
-    - jupyter_contrib_core >=0.2
-    - jupyter_core
-    - jupyter_nbextensions_configurator
-    - nbconvert
-    - notebook >=4.0
-    - psutil >=2.2.1
-    - pyyaml
     - setuptools
-    - tornado
-    - traitlets
 
   run:
     - python
     - ipython_genutils
-    - jupyter_contrib_core >=0.2
+    - jupyter_contrib_core >=0.3
     - jupyter_core
     - jupyter_nbextensions_configurator
     - nbconvert

--- a/recipes/jupyter_contrib_nbextensions/post-link.bat
+++ b/recipes/jupyter_contrib_nbextensions/post-link.bat
@@ -1,5 +1,6 @@
 @echo off
 :: We redirect stderr & stdout to conda's .messages.txt; for details, see
 ::     http://conda.pydata.org/docs/building/build-scripts.html
-"%PREFIX%\Scripts\jupyter.exe" contrib nbextension install --sys-prefix >> "%PREFIX%/.messages.txt" 2>&1
-if errorlevel 1 exit 1
+(
+  "%PREFIX%\Scripts\jupyter-contrib-nbextension.exe" install --sys-prefix
+) >>"%PREFIX%\.messages.txt" 2>&1

--- a/recipes/jupyter_contrib_nbextensions/post-link.sh
+++ b/recipes/jupyter_contrib_nbextensions/post-link.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
 # We redirect stderr & stdout to conda's .messages.txt; for details, see
 #     http://conda.pydata.org/docs/building/build-scripts.html
-"${PREFIX}/bin/jupyter" contrib nbextension install --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1
+{
+  "${PREFIX}/bin/jupyter-contrib-nbextension" install --sys-prefix
+} >>"${PREFIX}/.messages.txt" 2>&1

--- a/recipes/jupyter_contrib_nbextensions/pre-unlink.bat
+++ b/recipes/jupyter_contrib_nbextensions/pre-unlink.bat
@@ -1,5 +1,6 @@
 @echo off
 :: We redirect stderr & stdout to conda's .messages.txt; for details, see
 ::     http://conda.pydata.org/docs/building/build-scripts.html
-"%PREFIX%\Scripts\jupyter.exe" contrib nbextension uninstall --sys-prefix >> "%PREFIX%/.messages.txt" 2>&1
-if errorlevel 1 exit 1
+(
+  "%PREFIX%\Scripts\jupyter-contrib-nbextension.exe" uninstall --sys-prefix
+) >>"%PREFIX%\.messages.txt" 2>&1

--- a/recipes/jupyter_contrib_nbextensions/pre-unlink.sh
+++ b/recipes/jupyter_contrib_nbextensions/pre-unlink.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
 # We redirect stderr & stdout to conda's .messages.txt; for details, see
 # http://conda.pydata.org/docs/building/build-scripts.html
-"${PREFIX}/bin/jupyter" contrib nbextension uninstall --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1
+{
+  "${PREFIX}/bin/jupyter-contrib-nbextension" uninstall --sys-prefix
+} >>"${PREFIX}/.messages.txt" 2>&1


### PR DESCRIPTION
For https://github.com/conda-forge/staged-recipes/pull/1159.

Uses the canonically-generated conda names (seems more reliable). Also adds shebangs, and puts the commands inside a subshell.
